### PR TITLE
Add more content to papyri.info

### DIFF
--- a/modules/papyri.info/text.js
+++ b/modules/papyri.info/text.js
@@ -11,8 +11,8 @@ define(['jquery'], function($) {
         },
         parseData: function(html) {
             var getText = awld.accessor(html);
-            var h3Arr = getText('h3')
-            var mdtitle = getText('.mdtitle')
+            var h3Arr = getText('h3');
+            var mdtitle = getText('.mdtitle');
             return {
                 name: h3Arr[0] + "- " + mdtitle[0],
                 description: getText('#edition')


### PR DESCRIPTION
This has the same problem as Greek text in Perseus (no line breaks), as well as some additional minor ones due to e.g. line numbers and other formatting. But it might be useful at a glance.
